### PR TITLE
Fix enumeration operation may not execute

### DIFF
--- a/SEconomyPlugin/EventHandlers.cs
+++ b/SEconomyPlugin/EventHandlers.cs
@@ -332,9 +332,12 @@ namespace Wolfje.Plugins.SEconomy {
 				TaskScheduler.UnobservedTaskException -= TaskScheduler_UnobservedTaskException;
 				PayRunTimer.Elapsed -= PayRunTimer_Elapsed;
 				PayRunTimer.Dispose();
-				SquashJournalTimer.Elapsed -= SquashJournalTimer_Elapsed;
-				SquashJournalTimer.Dispose();
-
+				if (SquashJournalTimer != null)
+                {
+					SquashJournalTimer.Elapsed -= SquashJournalTimer_Elapsed;
+					SquashJournalTimer.Dispose();
+				}
+				
 				ServerApi.Hooks.GamePostInitialize.Deregister(this.Parent.PluginInstance, GameHooks_PostInitialize);
 				ServerApi.Hooks.ServerJoin.Deregister(this.Parent.PluginInstance, ServerHooks_Join);
 				ServerApi.Hooks.ServerLeave.Deregister(this.Parent.PluginInstance, ServerHooks_Leave);

--- a/SEconomyPlugin/Journal/MySQLJournal/MySQLTransactionJournal.cs
+++ b/SEconomyPlugin/Journal/MySQLJournal/MySQLTransactionJournal.cs
@@ -403,7 +403,7 @@ namespace Wolfje.Plugins.SEconomy.Journal.MySQLJournal
 			}
 
 			TShock.Log.ConsoleInfo("[SEconomy MySQL] Re-syncing online accounts");
-			foreach (TSPlayer player in TShockAPI.TShock.Players) {
+			foreach (TSPlayer player in TShockAPI.TShock.Players.ToList()) {
 				IBankAccount account = null;
 				if (player == null
 				    || player.Name == null

--- a/SEconomyPlugin/Journal/XMLJournal/XmlTransactionJournal.cs
+++ b/SEconomyPlugin/Journal/XMLJournal/XmlTransactionJournal.cs
@@ -691,7 +691,7 @@ namespace Wolfje.Plugins.SEconomy.Journal.XMLJournal {
             //abandon the old journal and assign the squashed one
             Console.WriteLine(SEconomyPlugin.Locale.StringOrDefault(82, "re-syncing online accounts."));
 
-            foreach (TSPlayer player in TShockAPI.TShock.Players) {
+            foreach (TSPlayer player in TShockAPI.TShock.Players.ToList()) {
                 IBankAccount account = null;
                 if (player == null
                     || SEconomyPlugin.Instance == null


### PR DESCRIPTION
Changed TShockAPI.TShock.Players to TShockAPI.TShock.Players.ToList(). Using .ToList() creates a separate instance of Players. This ensures that nothing else can modify it while the operation is running.

Also now we check if (SquashJournalTimer != null) before disposing of it to prevent NullReferenceException on exit